### PR TITLE
[FIX] updated tests using video sample

### DIFF
--- a/api_test_verification_photo.sh
+++ b/api_test_verification_photo.sh
@@ -16,7 +16,7 @@ SAMPLE_PNG_WFE="resources/samples/png_photo_wfe"
 BIG_SAMPLE_PNG="resources/samples/big.png"
 SAMPLE_LSF="resources/samples/little_second_face.jpg"
 SAMPLE_WAV="resources/samples/sound.wav"
-SAMPLE_WEBM="resources/samples/video.mov"
+VERTICAL_SAMPLE_MOV="resources/samples/vert_passive_video"
 SAMPLE_NF="resources/samples/no_face.jpg"
 SAMPLE_TF="resources/samples/two_face.jpg"
 EMPTY="resources/samples/empty"
@@ -87,7 +87,11 @@ f_test_extract() {
 
     TEST_NAME="extract 400. BPE-002003 – Не удалось прочитать биометрический образец. Sound file"
     REQUEST='curl -m '$TIMEOUT' -s -w "%{http_code}" -H "Content-Type:image/jpeg" --data-binary @'$SAMPLE_WAV' --output '$BODY' '$VENDOR_URL
-    f_check -r 400  -m "BPE-002003"
+    f_check -r 400 -m "BPE-002003"
+
+    TEST_NAME="extract 400. BPE-002003 – Не удалось прочитать биометрический образец. Video file"
+    REQUEST='curl -m '$TIMEOUT' -s -w "%{http_code}" -H "Content-Type:image/jpeg" --data-binary @'$VERTICAL_SAMPLE_MOV' --output '$BODY' '$VENDOR_URL
+    f_check -r 400 -m "BPE-002003"
 
     TEST_NAME="extract 400. BPE-003002 – На биометрическом образце отсутствует лицо. No face"
     REQUEST='curl -m '$TIMEOUT' -s -w "%{http_code}" -H "Content-Type:image/jpeg" -H "Expect:" --data-binary @'$SAMPLE_NF' --output '$BODY' '$VENDOR_URL
@@ -290,6 +294,14 @@ f_test_verify() {
 
     TEST_NAME="verify 400. BPE-002003 – Не удалось прочитать биометрический образец. Empty file"
     REQUEST='curl -m '$TIMEOUT' -s -w "%{http_code}" -H "Content-type:multipart/form-data" -F "bio_template=@'$BIOTEMPLATE';type=application/octet-stream" -F "sample=@'$EMPTY';type=image/jpeg" --output '$BODY' '$VENDOR_URL
+    f_check -r 400 -m "BPE-002003"
+
+    TEST_NAME="verify 400. BPE-002003 – Не удалось прочитать биометрический образец. Sound file"
+    REQUEST='curl -m '$TIMEOUT' -s -w "%{http_code}" -H "Content-type:multipart/form-data" -F "bio_template=@'$BIOTEMPLATE';type=application/octet-stream" -F "sample=@'$SAMPLE_WAV';type=image/jpeg" --output '$BODY' '$VENDOR_URL
+    f_check -r 400 -m "BPE-002003"
+
+    TEST_NAME="verify 400. BPE-002003 – Не удалось прочитать биометрический образец. Video file"
+    REQUEST='curl -m '$TIMEOUT' -s -w "%{http_code}" -H "Content-type:multipart/form-data" -F "bio_template=@'$BIOTEMPLATE';type=application/octet-stream" -F "sample=@'$VERTICAL_SAMPLE_MOV';type=image/jpeg" --output '$BODY' '$VENDOR_URL
     f_check -r 400 -m "BPE-002003"
 
     TEST_NAME="verify 400. BPE-002004 – Не удалось прочитать биометрический шаблон. Empty biotemplate"

--- a/api_test_verification_sound.sh
+++ b/api_test_verification_sound.sh
@@ -16,6 +16,7 @@ SAMPLE_SWV="resources/samples/sound_without_voice.wav"
 SAMPLE_SDV="resources/samples/sound_double_voice.wav"
 SAMPLE_PNG="resources/samples/photo.png"
 SAMPLE_JPG="resources/samples/photo.jpg"
+VERTICAL_SAMPLE_MOV="resources/samples/vert_passive_video"
 BIOTEMPLATE="tmp/biotemplate"
 
 
@@ -58,6 +59,10 @@ f_test_extract() {
     REQUEST='curl -m '$TIMEOUT' -s -w "%{http_code}" -H "Content-Type:audio/wav" -H "Expect:" --data-binary @'$SAMPLE_PNG'  --output '$BODY' '$VENDOR_URL
     f_check -r 400 -m "BPE-002003"
 
+    TEST_NAME="extract 400. BPE-002003 – Не удалось прочитать биометрический образец. Video file"
+    REQUEST='curl -m '$TIMEOUT' -s -w "%{http_code}" -H "Content-Type:audio/wav" -H "Expect:" --data-binary @'$VERTICAL_SAMPLE_MOV'  --output '$BODY' '$VENDOR_URL
+    f_check -r 400 -m "BPE-002003"
+
     TEST_NAME="extract 400. BPE-003002 – На биометрическом образце отсутствует голос. No voice"
     REQUEST='curl -m '$TIMEOUT' -s -w "%{http_code}" -H "Content-Type:audio/wav" -H "Expect:" --data-binary @'$SAMPLE_SWV' --output '$BODY' '$VENDOR_URL
     f_check -r 400 -m "BPE-003002"
@@ -80,7 +85,7 @@ f_test_compare() {
     # Tests
     TEST_NAME="compare 200"
     REQUEST='curl -m '$TIMEOUT' -s -w "%{http_code}" -H "Content-type:multipart/form-data" -F "bio_feature=@'$BIOTEMPLATE';type=application/octet-stream" -F "bio_template=@'$BIOTEMPLATE';type=application/octet-stream" -X POST --output '$BODY' '$VENDOR_URL
-    f_check -r 200 -m "[0-1].[0-9]" -f "- Score format double is expected"
+    f_check -r 200 -m "\"?[Ss]core\"?:\s?[0-1].[0-9]" -f "- Score format double is expected"
 
     TEST_NAME="compare 200. Without filename parameter"
     echo -ne '--72468\r\nContent-Disposition: form-data; name="bio_feature"\r\nContent-Type: application/octet-stream\r\n\r\n' > tmp/request_body; cat $BIOTEMPLATE >> tmp/request_body
@@ -238,6 +243,10 @@ f_test_verify() {
 
     TEST_NAME="verify 400. BPE-002003 – Не удалось прочитать биометрический образец. Photo file"
     REQUEST='curl -m '$TIMEOUT' -s -w "%{http_code}" -H "Content-type:multipart/form-data" -F "bio_template=@'$BIOTEMPLATE';type=application/octet-stream" -F "sample=@'$SAMPLE_JPG';type=audio/wav"  --output '$BODY' '$VENDOR_URL
+    f_check -r 400 -m "BPE-002003"
+
+    TEST_NAME="verify 400. BPE-002003 – Не удалось прочитать биометрический образец. Video file"
+    REQUEST='curl -m '$TIMEOUT' -s -w "%{http_code}" -H "Content-type:multipart/form-data" -F "bio_template=@'$BIOTEMPLATE';type=application/octet-stream" -F "sample=@'$VERTICAL_SAMPLE_MOV';type=audio/wav"  --output '$BODY' '$VENDOR_URL
     f_check -r 400 -m "BPE-002003"
 
     TEST_NAME="verify 400. BPE-002004 – Не удалось прочитать биометрический шаблон. Empty biotemplate"

--- a/include/f_test_passive_liveness_photo.sh
+++ b/include/f_test_passive_liveness_photo.sh
@@ -21,7 +21,7 @@ f_test_passive_liveness_photo() {
 
     EMPTY="resources/samples/empty"
     SAMPLE_WAV="resources/samples/sound.wav"
-    VERTICAL_SAMPLE_MP4="resources/samples/vert_passive_video.mp4"
+    VERTICAL_SAMPLE_MOV="resources/samples/vert_passive_video"
     SAMPLE_CAT_JPG="resources/samples/cat.jpg"
     SAMPLE_NF="resources/samples/no_face.jpg"
     SAMPLE_TF="resources/samples/two_face.jpg"
@@ -138,7 +138,7 @@ f_test_passive_liveness_photo() {
     f_check -r 400 -m "LDE-002004"
 
     TEST_NAME="detect 400. LDE-002004 – Не удалось прочитать биометрический образец. Video file"
-    REQUEST='curl -m '$TIMEOUT' -s -w "%{http_code}" -H "Expect:" -H "Content-Type:multipart/form-data" -F "metadata=@'$META';type=application/json" -F "bio_sample=@'$VERTICAL_SAMPLE_MP4';type=image/jpeg" --output '$BODY' '$VENDOR_URL
+    REQUEST='curl -m '$TIMEOUT' -s -w "%{http_code}" -H "Expect:" -H "Content-Type:multipart/form-data" -F "metadata=@'$META';type=application/json" -F "bio_sample=@'$VERTICAL_SAMPLE_MOV';type=image/jpeg" --output '$BODY' '$VENDOR_URL
     f_check -r 400 -m "LDE-002004"
 
     TEST_NAME="detect 400. LDE-002005 – Неверный Content-Type части multiparted HTTP-запроса. Invalid metadata type"
@@ -149,13 +149,13 @@ f_test_passive_liveness_photo() {
     REQUEST='curl -m '$TIMEOUT' -s -w "%{http_code}" -H "Content-Type:multipart/form-data" -F "metadata=@'$META';type=application/json" -F "bio_sample=@'$SAMPLE_JPG';type=application/json" --output '$BODY' '$VENDOR_URL
     f_check -r 400 -m "LDE-002005"
 
-    if [ "$TYPE" == "photo" ] ; then
+    if [ "$TYPE" == "photo" ]; then
         TEST_NAME="detect 400. LDE-002005 – Неверный Content-Type части multiparted HTTP-запроса. Invalid sample type"
         REQUEST='curl -m '$TIMEOUT' -s -w "%{http_code}" -H "Content-Type:multipart/form-data" -F "metadata=@'$META';type=application/json" -F "bio_sample=@'$SAMPLE_JPG';type=audio/wav" --output '$BODY' '$VENDOR_URL
         f_check -r 400 -m "LDE-002005"
 
         TEST_NAME="detect 400. LDE-002005 – Неверный Content-Type части multiparted HTTP-запроса. Invalid sample type"
-        REQUEST='curl -m '$TIMEOUT' -s -w "%{http_code}" -H "Content-Type:multipart/form-data" -F "metadata=@'$META';type=application/json" -F "bio_sample=@'$SAMPLE_JPG';type=video/mp4" --output '$BODY' '$VENDOR_URL
+        REQUEST='curl -m '$TIMEOUT' -s -w "%{http_code}" -H "Content-Type:multipart/form-data" -F "metadata=@'$META';type=application/json" -F "bio_sample=@'$SAMPLE_JPG';type=video/mov" --output '$BODY' '$VENDOR_URL
         f_check -r 400 -m "LDE-002005"
 
     elif [ "$TYPE" == "photo+p_video" ]; then

--- a/include/f_test_passive_liveness_sound.sh
+++ b/include/f_test_passive_liveness_sound.sh
@@ -18,7 +18,7 @@ f_test_passive_liveness_sound() {
 
     EMPTY="resources/samples/empty"
     SAMPLE_JPG="resources/samples/photo_shumskiy.jpg"
-    VERTICAL_SAMPLE_MP4="resources/samples/vert_passive_video.mp4"
+    VERTICAL_SAMPLE_MOV="resources/samples/vert_passive_video"
     SAMPLE_NV="resources/samples/sound_without_voice.wav"
     SAMPLE_DV="resources/samples/sound_double_voice.wav"
 
@@ -109,7 +109,7 @@ f_test_passive_liveness_sound() {
     f_check -r 400 -m "LDE-002004"
 
     TEST_NAME="detect 400. LDE-002004 – Не удалось прочитать биометрический образец. Video file"
-    REQUEST='curl -m '$TIMEOUT' -s -w "%{http_code}" -H "Content-Type:multipart/form-data" -F "metadata=@'$META';type=application/json" -F "bio_sample=@'$VERTICAL_SAMPLE_MP4';type=audio/wav" --output '$BODY' '$VENDOR_URL
+    REQUEST='curl -m '$TIMEOUT' -s -w "%{http_code}" -H "Content-Type:multipart/form-data" -F "metadata=@'$META';type=application/json" -F "bio_sample=@'$VERTICAL_SAMPLE_MOV';type=audio/wav" --output '$BODY' '$VENDOR_URL
     f_check -r 400 -m "LDE-002004"
 
     TEST_NAME="detect 400. LDE-002005 – Неверный Content-Type части multiparted HTTP-запроса. Invalid metadata type"
@@ -129,7 +129,7 @@ f_test_passive_liveness_sound() {
     f_check -r 400 -m "LDE-002005"
 
     TEST_NAME="detect 400. LDE-002005 – Неверный Content-Type части multiparted HTTP-запроса. Invalid sample type"
-    REQUEST='curl -m '$TIMEOUT' -s -w "%{http_code}" -H "Content-Type:multipart/form-data" -F "metadata=@'$META';type=application/json" -F "bio_sample=@'$SAMPLE_WAV';type=video/webm" --output '$BODY' '$VENDOR_URL
+    REQUEST='curl -m '$TIMEOUT' -s -w "%{http_code}" -H "Content-Type:multipart/form-data" -F "metadata=@'$META';type=application/json" -F "bio_sample=@'$SAMPLE_WAV';type=video/mov" --output '$BODY' '$VENDOR_URL
     f_check -r 400 -m "LDE-002005"
 
     TEST_NAME="detect 400. LDE-003002 – На биометрическом образце отсутствует голос. No voice"


### PR DESCRIPTION
Для `api_test_verification_photo.sh`, `api_test_verification_sound.sh`, `api_test_liveness.sh` актуализированы негативные тесты с использованием видео-сэмпла.